### PR TITLE
fix: incorrect prefix-default in master manifest rewrite

### DIFF
--- a/index.js
+++ b/index.js
@@ -236,7 +236,7 @@ const getMasterManifest = async (encodedPayload, opts) => {
 };
 
 const rewriteMasterManifest = async (manifest, encodedPayload, opts) => {
-  const prefix = process.env.PREFIX ? process.env.PREFIX : 'stitch';
+  const prefix = process.env.PREFIX ? process.env.PREFIX : '/stitch';
   let rewrittenManifest = "";
   const lines = manifest.split("\n");
   let bw = null;


### PR DESCRIPTION
This PR resolves a bug where the prefix to be used when PREFIX env variable was not set was incorrect.